### PR TITLE
Add server constructor with ApplicationEngineEnvironment

### DIFF
--- a/suspendapp-ktor/api/suspendapp-ktor.api
+++ b/suspendapp-ktor/api/suspendapp-ktor.api
@@ -1,4 +1,6 @@
 public final class arrow/continuations/ktor/KtorServerKt {
+	public static final fun server-NrqJHPo (Larrow/fx/coroutines/continuations/ResourceScope;Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/engine/ApplicationEngineEnvironment;JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun server-NrqJHPo$default (Larrow/fx/coroutines/continuations/ResourceScope;Lio/ktor/server/engine/ApplicationEngineFactory;Lio/ktor/server/engine/ApplicationEngineEnvironment;JJJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun server-T7_icE8 (Larrow/fx/coroutines/continuations/ResourceScope;Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;JJJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun server-T7_icE8$default (Larrow/fx/coroutines/continuations/ResourceScope;Lio/ktor/server/engine/ApplicationEngineFactory;ILjava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;JJJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }

--- a/suspendapp-ktor/src/commonMain/kotlin/arrow/continuations/ktor/KtorServer.kt
+++ b/suspendapp-ktor/src/commonMain/kotlin/arrow/continuations/ktor/KtorServer.kt
@@ -63,6 +63,41 @@ suspend fun <
     engine.environment.log.info("HTTP server shutdown!")
   }
 
+/**
+ * Ktor [ApplicationEngine] as a [Resource]. This [Resource] will gracefully shut down the server
+ * When we need to shut down a Ktor service we need to properly take into account a _grace_ period
+ * where we still handle requests instead of immediately cancelling any in-flight requests.
+ *
+ * @param factory Application engine for processing the requests
+ * @param environment definition of the environment where the engine will run
+ * @param preWait preWait a duration to wait before beginning the stop process. During this time,
+ *   requests will continue to be accepted. This setting is useful to allow time for the container
+ *   to be removed from the load balancer. This is disabled when `io.ktor.development=true`.
+ * @param grace grace a duration during which already inflight requests are allowed to continue
+ *   before the shutdown process begins.
+ * @param timeout timeout a duration after which the server will be forceably shutdown.
+ */
+suspend fun <
+  TEngine : ApplicationEngine, TConfiguration : ApplicationEngine.Configuration> ResourceScope
+  .server(
+  factory: ApplicationEngineFactory<TEngine, TConfiguration>,
+  environment: ApplicationEngineEnvironment,
+  preWait: Duration = 30.seconds,
+  grace: Duration = 500.milliseconds,
+  timeout: Duration = 500.milliseconds
+): ApplicationEngine =
+  install({ embeddedServer(factory, environment).apply(ApplicationEngine::start) }) { engine, _ ->
+    if (!engine.environment.developmentMode) {
+      engine.environment.log.info(
+        "prewait delay of ${preWait.inWholeMilliseconds}ms, turn it off using io.ktor.development=true"
+      )
+      delay(preWait.inWholeMilliseconds)
+    }
+    engine.environment.log.info("Shutting down HTTP server...")
+    engine.stop(grace.inWholeMilliseconds, timeout.inWholeMicroseconds)
+    engine.environment.log.info("HTTP server shutdown!")
+  }
+
 // Ported from Ktor:
 // https://github.com/ktorio/ktor/blob/0de7948fbe3f78673f4f90de9c5ea5986691819a/ktor-server/ktor-server-host-common/jvmAndNix/src/io/ktor/server/engine/ServerEngineUtils.kt
 internal expect val WORKING_DIRECTORY_PATH: String


### PR DESCRIPTION
This PR tries to solve the need for ssl configuration (or any other that can by done through `ApplicationEngineEnvironment`) in Ktor Server using suspendapp